### PR TITLE
Fix not null check of addTupel in Block

### DIFF
--- a/src/main/java/join/datastructures/Block.java
+++ b/src/main/java/join/datastructures/Block.java
@@ -34,7 +34,7 @@ public final class Block implements Iterable<Tuple> {
 	}
 
 	public boolean addTuple(Tuple tuple) {
-		Objects.requireNonNull(gate, "tuple must not be null");
+		Objects.requireNonNull(tuple, "tuple must not be null");
 
 		checkAccess("cannot write to unpinned block");
 


### PR DESCRIPTION
In the method `addTuple` in the class `Block` it was required that `gate` is not null but the argument is actually `tuple`. And the `gate` variable was already checked in the constructor.